### PR TITLE
Fix issue where not all pkgs_to_not_remove are checked.

### DIFF
--- a/lib/yum-plugins/replace.py
+++ b/lib/yum-plugins/replace.py
@@ -207,7 +207,8 @@ Replace a package with another that provides the same thing"""
         # This is messy: determine if any of the pkgs_to_not_remove have
         # counterparts as part of same 'base name' set (but different srpm, i.e. 
         # php and php-pear has different source rpms but you want phpXY-pear too).
-        for pkg in pkgs_to_not_remove:
+        while pkgs_to_not_remove:
+            pkg = pkgs_to_not_remove.pop()
             m = re.match('%s-(.*)' % orig_pkg, pkg.name)
             if not m:
                 continue


### PR DESCRIPTION
I found a bug in replace.py, where only one entry in pkgs_to_not_remove is performing the "messy" counterpart checks when not in the same SRPM. Essentially pkgs_to_not_remove being altered while looping, and so ending the loop prematurely.

Steps to reproduce:

```
yum install php php-pecl-memcache
yum replace php --replace-with=php54
```

Expecting to see:

```
Installing:
  php54-pecl-memcache
Removing:
  php-pecl-memcache
```

Actual result:

```
Removing for dependencies:
  php-pecl-memcache
```

I've included a fix which corrects this issue.
