### PR TITLE
Check for counterparts using the original and new package sourcerpm name

### DIFF
--- a/lib/yum-plugins/replace.py
+++ b/lib/yum-plugins/replace.py
@@ -153,6 +153,20 @@ Replace a package with another that provides the same thing"""
         new_pkgobject = new_pkgs[0]
         pkgs_to_install.append(new_pkgobject)
 
+        orig_prefix = orig_pkg
+        new_prefix = new_pkg
+
+        # Find the original and new prefixes of packages based on their sourcerpm name
+        m = re.match('(.*)-%s-%s' % (orig_pkgobject.version, orig_pkgobject.release),\
+            orig_pkgobject.sourcerpm)
+        if m:
+            orig_prefix = m.group(1)
+
+        m = re.match('(.*)-%s-%s' % (new_pkgobject.version, new_pkgobject.release),\
+            new_pkgobject.sourcerpm)
+        if m:
+            new_prefix = m.group(1)
+
         # don't remove pkgs that rely on orig_pkg (yum tries to remove them)
         for pkg in base.rpmdb:
             for req in pkg.requires_names:
@@ -173,7 +187,7 @@ Replace a package with another that provides the same thing"""
                             if not providers.has_key(dep):
                                 providers[dep] = []
                             providers[dep].append(pkg)
-                            
+
         # We now have a complete list of package providers we care about
         if providers:
             resolved = False
@@ -186,7 +200,7 @@ Replace a package with another that provides the same thing"""
                 elif len(pkgs) > 1:
                     # Attempt to auto resolve multiple provides
                     for rpkg in pkgs_to_remove:
-                        npkg = rpkg.name.replace(orig_pkg, new_pkg)
+                        npkg = rpkg.name.replace(orig_prefix, new_prefix)
                         for pkg in pkgs:
                             if npkg == pkg.name:
                                 pkgs_to_install.append(pkg)
@@ -203,20 +217,6 @@ Replace a package with another that provides the same thing"""
 
                 # remove the dep from dict since it should be handled.
                 del(providers[key])
-
-        orig_prefix = orig_pkg
-        new_prefix = new_pkg
-
-        # Find the original and new prefixes of packages based on their sourcerpm name
-        m = re.match('(.*)-%s-%s' % (orig_pkgobject.version, orig_pkgobject.release),\
-            orig_pkgobject.sourcerpm)
-        if m:
-            orig_prefix = m.group(1)
-
-        m = re.match('(.*)-%s-%s' % (new_pkgobject.version, new_pkgobject.release),\
-            new_pkgobject.sourcerpm)
-        if m:
-            new_prefix = m.group(1)
 
         # This is messy: determine if any of the pkgs_to_not_remove have
         # counterparts as part of same 'base name' set (but different srpm, i.e. 


### PR DESCRIPTION
I would like my guides that use this plugin to not have to install the package matching the base prefix.

This is because for example, running php-fpm and switching to php54-fpm would require installing httpd as part of the php package installation (as it's really mod_php sapi).

The same goes with mysql-server requiring mysql client installed.

Currently, if you don't use the base package, the plugin doesn't resolve the package upgrades of packages matching the base prefix if from another SRPM.

For example:

```
yum install php-cli php-pear
# causes an error because php isn't installed
yum replace php --replace-with php54
# removes php-pear and doesn't install the php54-pear package
yum replace php-common --replace-with php54-common
```

What I suggest, and have added to this pull request, is to resolve the source rpm name from it's filename, which works for most cases.

After (with the other pull request)

```
yum replace php-common --replace-with php54-common # replaces all php packages with php54 without needing the php base package installed
```

If there's any easier way of finding the source rpm name, then that'd be better, but this, along with my other pull request, should presumably work with all IUS packages as well as mine.
