### PR TITLE
Add standard checks for root/gpgkeys

### DIFF
--- a/lib/yum-plugins/replace.py
+++ b/lib/yum-plugins/replace.py
@@ -24,7 +24,7 @@ import platform
 from yum.plugins import TYPE_CORE, TYPE_INTERACTIVE
 from yum.Errors import UpdateError, RemoveError
 from yum.constants import PLUG_OPT_STRING, PLUG_OPT_WHERE_ALL
-from yumcommands import checkRootUID, checkGPGKey, checkEnabledRepo
+from yumcommands import checkRootUID, checkGPGKey
 
 requires_api_version = '2.6'
 plugin_type = (TYPE_CORE, TYPE_INTERACTIVE)
@@ -80,7 +80,6 @@ Replace a package with another that provides the same thing"""
     def doCheck(self, base, basecmd, extcmds):
         checkRootUID(base)
         checkGPGKey(base)
-        checkEnabledRepo(base, extcmds)
 
     def doCommand(self, base, basecmd, extcmds):
         logger = logging.getLogger("yum.verbose.main")


### PR DESCRIPTION
When yum replace is run as a non-privileged user, it doesn't complain, and attempts to do the install/remove.

Sometimes this doesn't even result in an error and leaves the user confused as to why their package is still the old one.

These checks stop that happening, along with additionally doing some other sanity checks that yum install/update also does.
