### PR TITLE
Update GitHub URL in README

### DIFF
--- a/README
+++ b/README
@@ -37,7 +37,7 @@ CODE/BUGS/ETC
 
 The source code for yum-plugin-replace is currently hosted on GitHub:
 
-    http://github.com/derks/yum-plugin-replace
+    https://github.com/iuscommunity/yum-plugin-replace
 
 All bugs/feature requests can be reported there.
 


### PR DESCRIPTION
https://github.com/derks/yum-plugin-replace is now returning 404, so it's either been taken down or is a private repository.